### PR TITLE
fix: ensure skipped checks are treated properly

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11235,6 +11235,10 @@ function appInspect({ user, password, filePath, includedTags, excludedTags, fail
                             (0,core.info)(`A manual check is required:\n${msg}`);
                         }
                         break;
+                    case 'skipped':
+                        for (const msg of checkMessages(check)) {
+                            (0,core.info)(`A check was skipped:\n${msg}`);
+                        }
                     case 'success':
                     case 'not_applicable':
                         // ignore

--- a/src/api.ts
+++ b/src/api.ts
@@ -124,7 +124,7 @@ export interface Check {
     messages: Message[];
     name: string;
     tags: string[];
-    result: 'success' | 'not_applicable' | 'manual_check' | 'failure' | 'error' | 'warning';
+    result: 'success' | 'not_applicable' | 'manual_check' | 'failure' | 'error' | 'warning' | 'skipped';
 }
 
 export interface Group {

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,6 +130,10 @@ async function appInspect({
                         info(`A manual check is required:\n${msg}`);
                     }
                     break;
+                case 'skipped':
+                    for (const msg of checkMessages(check)) {
+                        info(`A check was skipped:\n${msg}`); 
+                    }
                 case 'success':
                 case 'not_applicable':
                     // ignore


### PR DESCRIPTION
In some circumstances, the Appinspect API skips checks. Currently, those checks are not processed correctly. This ensures that the script does fail once a skipped check is encountered.