### PR TITLE
fix: extend max retries for submitting package

### DIFF
--- a/main.py
+++ b/main.py
@@ -162,7 +162,7 @@ def submit(
                 "Authorization": f"bearer {token}",
             },
             rand=lambda: seconds_to_wait,
-            num_retries=20,
+            num_retries=25,
             validation_function=_validate_validation_status,
         )
     except CouldNotAuthenticateException:


### PR DESCRIPTION
Increase time for sending and verifying package by appinspect api.

appinspect-api action used to correctly submit and veirfy package for mscs TA:
https://github.com/splunk/splunk-add-on-for-microsoft-cloud-services/actions/runs/6369944655/job/17290679616

Now it hits time limit: https://github.com/splunk/splunk-add-on-for-microsoft-cloud-services/actions/runs/6402222678/job/17378649724